### PR TITLE
Added ability to set MediaPlayer.OnErrorListener in prepare() and prepareAsync()

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=1.0.1
-VERSION_CODE=2
+VERSION_NAME=1.0.2
+VERSION_CODE=3
 GROUP=com.yqritc
 ARTIFACT_ID=android-scalablevideoview
 

--- a/library/src/main/java/com/yqritc/scalablevideoview/ScalableVideoView.java
+++ b/library/src/main/java/com/yqritc/scalablevideoview/ScalableVideoView.java
@@ -165,16 +165,28 @@ public class ScalableVideoView extends TextureView implements TextureView.Surfac
         scaleVideoSize(getVideoWidth(), getVideoHeight());
     }
 
-    public void prepare(@Nullable MediaPlayer.OnPreparedListener listener)
+    public void prepare(@Nullable MediaPlayer.OnPreparedListener listener, @Nullable MediaPlayer.OnErrorListener eListener)
             throws IOException, IllegalStateException {
         mMediaPlayer.setOnPreparedListener(listener);
+        mMediaPlayer.setOnErrorListener(eListener);
         mMediaPlayer.prepare();
+    }
+
+    public void prepareAsync(@Nullable MediaPlayer.OnPreparedListener listener, @Nullable MediaPlayer.OnErrorListener eListener)
+            throws IllegalStateException {
+        mMediaPlayer.setOnPreparedListener(listener);
+        mMediaPlayer.setOnErrorListener(eListener);
+        mMediaPlayer.prepareAsync();
+    }
+
+    public void prepare(@Nullable MediaPlayer.OnPreparedListener listener)
+            throws IOException, IllegalStateException {
+        prepare(listener, null);
     }
 
     public void prepareAsync(@Nullable MediaPlayer.OnPreparedListener listener)
             throws IllegalStateException {
-        mMediaPlayer.setOnPreparedListener(listener);
-        mMediaPlayer.prepareAsync();
+        prepareAsync(listener, null);
     }
 
     public void prepare() throws IOException, IllegalStateException {


### PR DESCRIPTION
Now you can set `OnErrorListener` in `prepare()` and `prepareAsync()` methods:
```
mVideoView.prepareAsync(new MediaPlayer.OnPreparedListener() {
    @Override
    public void onPrepared(MediaPlayer mp) {
        Log.v("mVideoView", "onPrepared");
    }
}, new MediaPlayer.OnErrorListener() {
    @Override
    public boolean onError(MediaPlayer mp, int what, int extra) {
        Log.e("mVideoView", "Error: " + waht);
        return false;
    }
});
```

Basically added 2 new methods:
```
public void prepare(@Nullable MediaPlayer.OnPreparedListener listener, @Nullable MediaPlayer.OnErrorListener eListener)
            throws IOException, IllegalStateException

public void prepareAsync(@Nullable MediaPlayer.OnPreparedListener listener, @Nullable MediaPlayer.OnErrorListener eListener)
            throws IllegalStateException
```