### PR TITLE
fix IllegalStateException in onDetachedFromWindow

### DIFF
--- a/library/src/main/java/com/yqritc/scalablevideoview/ScalableVideoView.java
+++ b/library/src/main/java/com/yqritc/scalablevideoview/ScalableVideoView.java
@@ -240,5 +240,6 @@ public class ScalableVideoView extends TextureView implements TextureView.Surfac
     public void release() {
         mMediaPlayer.reset();
         mMediaPlayer.release();
+        mMediaPlayer = null;
     }
 }


### PR DESCRIPTION
fix IllegalStateException when release called release before onDetachedFromWindow.

Details:
In my HM note(China Xiaomi Inc), I use ScalableVideoView in fragment, I init ScalableVideoView in onViewCreated method, and when I destroy this fragment and recreate it again, the video could not be played, when I call ScalableVideoView.release() in onDestroyView method, the video could be played again in the condition above, but my app will crash with IllegalStateException, when the fragment is destroyed again.

I think set `mMediaPlayer = null;` in `release()` method could be solve this problem, and it does in my project (I introduce this repo's source into my project and set `mMediaPlayer = null;`, and the crash goes off).